### PR TITLE
Improve Routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html> 

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,32 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>UCI Blueprint</title>
+
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+    
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { HashRouter, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 import Home from "./components/Home/Home";
 import About from "./components/About/About";
 import Projects from "./components/Projects/Projects";
@@ -8,17 +8,15 @@ import Navbar from "./components/Page/Navbar";
 
 function App() {
   return (
-    <HashRouter>
-      <div className='App'>
-        <Navbar />
-        <Switch>
-          <Route path='/' exact component={Home} />
-          <Route path='/about' exact component={About} />
-          <Route path='/projects' exact component={Projects} />
-          <Route path='/contact' exact component={Contact} />
-        </Switch>
-      </div>
-    </HashRouter>
+    <div className='App'>
+      <Navbar />
+      <Switch>
+        <Route path='/' exact component={Home} />
+        <Route path='/about' exact component={About} />
+        <Route path='/projects' exact component={Projects} />
+        <Route path='/contact' exact component={Contact} />
+      </Switch>
+    </div>
   );
 }
 

--- a/src/components/Page/Footer.js
+++ b/src/components/Page/Footer.js
@@ -21,9 +21,9 @@ export default function Footer() {
                 <h2>General</h2>
                 <ul>
                     <a href="/"><li>Home</li></a>
-                    <a href="/#/about"><li>About</li></a>
-                    <a href="/#/projects"><li>Projects</li></a>
-                    <a href="/#/contact"><li>Contact</li></a>
+                    <a href="/about"><li>About</li></a>
+                    <a href="/projects"><li>Projects</li></a>
+                    <a href="/contact"><li>Contact</li></a>
                 </ul>
             </div>
             

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom";
 import "./base.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
Our routes no longer need the `#` in them! 

I found a way to exploit the 404 page, in order to enable proper routing for SPA React Sites on GitHub Pages. 
Basically, we have a 404.html page that redirects to index.html, including the route as query params. Our index.html takes those query params, redirects to the correct page, and updates the browser history accordingly.

Full explanation can be found here: https://github.com/rafgraph/spa-github-pages#how-it-works

I've already deployed this routing branch to verify that everything works. Sorry for doing our review process a bit backwards but it didn't make sense to open this PR without testing that the change worked as intended. 
_(And it would've been a simple rollback to redeploy the previous master, had anything gone wrong)_  

Feel free to check it out for yourself :) 
- https://uciblueprint.org/about
- https://uciblueprint.org/projects
- https://uciblueprint.org/contact